### PR TITLE
Integrate opencover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ bld/
 *.VisualState.xml
 TestResult.xml
 
+# OpenCover
+CodeCoverage.xml
+
 # Build Results of an ATL Project
 [Dd]ebugPS/
 [Rr]eleasePS/

--- a/EFRepository.Tests/packages.config
+++ b/EFRepository.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EntityFramework" version="6.1.3" targetFramework="net461" />
+  <package id="OpenCover" version="4.6.519" targetFramework="net461" />
   <package id="SpecFlow" version="2.1.0" targetFramework="net461" />
   <package id="SpecFlow.MsTest" version="2.1.0" targetFramework="net461" />
 </packages>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ build:
   parallel: true
   publish_wap: true
   verbosity: minimal
+  project: EFRepository.sln
 
-test:
-  assemblies:
-    - '**\*.Tests.dll'
+test_script:  
+  - packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -target:vstest.console.exe -targetargs:"/logger:Appveyor EFRepository.Tests\bin\Release\EFRepository.Tests.dll" -output:CodeCoverage.xml


### PR DESCRIPTION
Integrate opencover to calculate unit test code coverage.
